### PR TITLE
Use babel-preset-env instead of deprecated babel-preset-es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    "env",
     "react"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.3.13",
     "babelify": "^7.3.0",


### PR DESCRIPTION
This is a fix for #17 