### PR TITLE
Call `this.onClose` after pressing <Escape> key

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,7 +25,7 @@ export default class ModalVideo extends React.Component {
 
   keydownHandler(e) {
     if (e.keyCode === 27) {
-      this.setState({ isOpen: false })
+      this.closeModal();
     }
   }
 


### PR DESCRIPTION
Before this change, the modal would not call the provided `onClose` prop if the user pressed <kbd>Escape</kbd>.