### PR TITLE
Fix escape key listener

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -30,11 +30,11 @@ export default class ModalVideo extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('keydown', this.keydownHandler.bind(this), false);
+    document.addEventListener('keydown', this.keydownHandler.bind(this));
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keydown', this.keydownHandler);
+    document.removeEventListener('keydown', this.keydownHandler.bind(this));
   }
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
When component unmount, the escape key is still binded because the listeners are not the same.
![image](https://user-images.githubusercontent.com/45731/56072505-abd0fd80-5da8-11e9-9dc8-75c8b983365a.png)

ref: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener

