### PR TITLE
Remove use of deprecated React lifecycle hook

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -37,8 +37,8 @@ export default class ModalVideo extends React.Component {
     document.removeEventListener('keydown', this.keydownHandler.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.setState({isOpen: nextProps.isOpen})
+  static getDerivedStateFromProps(props) {
+    return { isOpen: props.isOpen };
   }
 
   componentDidUpdate () {


### PR DESCRIPTION
For React 16.3 and later componentWillReceiveProps was deprecated. I have replaced it with getDerivedStateFromProps which was introduced as a replacement.